### PR TITLE
Call UseVisual on task use

### DIFF
--- a/moon/amongus/gamemode/tasks/base.moon
+++ b/moon/amongus/gamemode/tasks/base.moon
@@ -310,6 +310,7 @@ if SERVER
 		--- Called whenever the assigned player uses the button. (opens the UI)
 		-- Don't forget to base-call this if you want a VGUI.
 		.OnUse = (btn) =>
+			@UseVisual btn
 			playerTable = @GetAssignedPlayer!
 			if GAMEMODE\Player_CanOpenVGUI playerTable
 				GAMEMODE\Player_OpenVGUI playerTable, @GetName!, { taskName: @GetName! }, (-> @Cancel btn)

--- a/moon/amongus/gamemode/tasks/base.moon
+++ b/moon/amongus/gamemode/tasks/base.moon
@@ -185,6 +185,7 @@ if SERVER
 		--- Internal function.
 		-- Called whenever the assigned player uses the button. (opens the UI)
 		.Use = (btn) =>
+			@UseVisual btn
 			@OnUse btn
 
 		--- Internal function.
@@ -310,7 +311,6 @@ if SERVER
 		--- Called whenever the assigned player uses the button. (opens the UI)
 		-- Don't forget to base-call this if you want a VGUI.
 		.OnUse = (btn) =>
-			@UseVisual btn
 			playerTable = @GetAssignedPlayer!
 			if GAMEMODE\Player_CanOpenVGUI playerTable
 				GAMEMODE\Player_OpenVGUI playerTable, @GetName!, { taskName: @GetName! }, (-> @Cancel btn)


### PR DESCRIPTION
`OnTaskUse` outputs aren't being fired without this.