### PR TITLE
Add a convar for setting the corpse model

### DIFF
--- a/src/gamemodes/amongus/gamemode/shared.moon
+++ b/src/gamemodes/amongus/gamemode/shared.moon
@@ -74,6 +74,8 @@ GM.ConVars =
 
 	PlayerModel: CreateConVar "au_player_model", "models/amongus/player/player.mdl",
 		flags, ""
+	CorpseModel: CreateConVar "au_corpse_model", "models/amongus/player/corpse.mdl",
+		flags, ""
 
 --- Enum of all colors players can get.
 -- @table GM.Colors
@@ -488,6 +490,13 @@ GM.GetDefaultPlayerModel = =>
 		defaultModel = @ConVars.PlayerModel\GetDefault!
 
 	return defaultModel
+
+GM.GetDefaultCorpseModel = =>
+	defaultCorpse = @ConVars.CorpseModel\GetString!
+	if nil == defaultCorpse or "" == defaultCorpse
+		defaultCorpse = @ConVars.CorpseModel\GetDefault!
+
+	return defaultCorpse
 
 local logger
 logger = {

--- a/src/gamemodes/amongus/gamemode/shared.moon
+++ b/src/gamemodes/amongus/gamemode/shared.moon
@@ -492,9 +492,9 @@ GM.GetDefaultPlayerModel = =>
 	return defaultModel
 
 GM.GetDefaultCorpseModel = =>
-	defaultCorpse = @ConVars.CorpseModel\GetString!
+	defaultCorpse = @ConVarSnapshots.CorpseModel\GetString!
 	if nil == defaultCorpse or "" == defaultCorpse
-		defaultCorpse = @ConVars.CorpseModel\GetDefault!
+		defaultCorpse = @ConVarSnapshots.CorpseModel\GetDefault!
 
 	return defaultCorpse
 

--- a/src/gamemodes/amongus/gamemode/sv_player.moon
+++ b/src/gamemodes/amongus/gamemode/sv_player.moon
@@ -94,7 +94,7 @@ GM.Player_Kill = (victimTable, attackerTable) =>
 	with corpse = ents.Create "prop_ragdoll"
 		\SetPos victimTable.entity\GetPos!
 		\SetAngles victimTable.entity\GetAngles!
-		\SetModel "models/amongus/player/corpse.mdl"
+		\SetModel GAMEMODE\GetDefaultCorpseModel!
 		\SetCollisionGroup COLLISION_GROUP_DEBRIS_TRIGGER
 		\SetUseType SIMPLE_USE
 


### PR DESCRIPTION
This adds the `au_corpse_model` convar which allows server operators to override the default corpse model in addition to the default player model with `au_player_model`.

**TODO:** Allow server operators to customize corpse models per-player, like they can with the `PlayerSetModel` hook for playermodels.

Fixes #59.