### PR TITLE
Don't reset env_soundcape* entities on cleanup

### DIFF
--- a/src/gamemodes/amongus/gamemode/sv_game.moon
+++ b/src/gamemodes/amongus/gamemode/sv_game.moon
@@ -74,7 +74,7 @@ GM.Game_CleanUp = (soft) =>
 	timer.Remove "NMW AU CheckWin"
 
 	if not soft
-		game.CleanUpMap!
+		game.CleanUpMap false, { 'env_soundscape', 'env_soundscape_proxy', 'env_soundscape_triggerable' }
 
 GM.Game_Start = =>
 	-- Bail if the manifest is missing or malformed.

--- a/src/gamemodes/amongus/gamemode/sv_game.moon
+++ b/src/gamemodes/amongus/gamemode/sv_game.moon
@@ -74,7 +74,11 @@ GM.Game_CleanUp = (soft) =>
 	timer.Remove "NMW AU CheckWin"
 
 	if not soft
-		game.CleanUpMap false, { 'env_soundscape', 'env_soundscape_proxy', 'env_soundscape_triggerable' }
+		game.CleanUpMap false, {
+			"env_soundscape"
+			"env_soundscape_proxy"
+			"env_soundscape_triggerable"
+		}
 
 GM.Game_Start = =>
 	-- Bail if the manifest is missing or malformed.


### PR DESCRIPTION
Apparently, GMod/Source yeets half the soundscape entities on au_skeld when the map is cleaned up. Not cleaning up soundscape entities seems to fix this issue.

Possibly related issue from 5 years ago about the wrong entity type: Facepunch/garrysmod-issues#2272