### PR TITLE
Fix eject typing effect for multibyte characters

### DIFF
--- a/src/gamemodes/amongus/gamemode/vgui/vgui_eject.moon
+++ b/src/gamemodes/amongus/gamemode/vgui/vgui_eject.moon
@@ -76,17 +76,20 @@ eject.WriteText = (text, subtext) =>
 					draw.SimpleText subtext, "NMW AU Eject Subtext", w/2, h/2, color,
 						TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER, 2, COLOR_OUTLINE
 
+	textLen = utf8.len(text)
 	i = 0
 	callback = ->
 		i += 1
 
-		@ejectTextLabel.Text ..= text[i]
+		char = utf8.GetChar(text, i)
 
-		if text[i] ~= "" and text[i] ~= " "
+		@ejectTextLabel.Text ..= char
+
+		if char ~= "" and char ~= " "
 			surface.PlaySound "au/eject_text.ogg"
 
-		if i ~= #text
-			@ejectTextLabel\NewAnimation 1.5/#text, 0, 0, callback
+		if i ~= textLen
+			@ejectTextLabel\NewAnimation 1.5/textLen, 0, 0, callback
 		elseif @ejectTextSubLabel
 			@ejectTextSubLabel\AlphaTo 255, 0.25, 1
 


### PR DESCRIPTION
Before this patch, multi-byte characters would require two calls to `callback` to appear, with the Unicode replacement character appearing before the whole byte sequence had been written out:

![pre-patch typing animation](https://user-images.githubusercontent.com/5623770/102024239-830bc300-3d56-11eb-88db-461e959b58e0.png)