### PR TITLE
Discourage direct Lua file modification

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ const renderSvg = require('./tools/resvg');
 const minifyLua = require('./tools/luamin');
 const compileMoonscript = require('./tools/moonscript');
 const optimizeLua = require ('./tools/optimizations');
+const discourageLuaMod = require ('./tools/discourageLuaModification');
 
 const lastRunCache = new Map();
 function lastRunIgnoreErrors(task) {
@@ -67,6 +68,7 @@ function moon() {
 	return gulp.src('src/**/*.moon', { since: lastRunIgnoreErrors(moon) })
 		.pipe(compileMoonscript())
 		.pipe(optimizeLua())
+		.pipe(discourageLuaMod())
 		// .pipe(minifyLua())
 		.pipe(gulp.dest('dest', { mode: 0777 }));
 }

--- a/tools/discourageLuaModification.js
+++ b/tools/discourageLuaModification.js
@@ -1,0 +1,54 @@
+const { Transform } = require('stream');
+
+const { streamToBuffer } = require('./util');
+
+const LUA_FILE_PREFIX =
+`-- !!! THIS FILE IS COMPILED !!!
+-- This gamemode is written in Moonscript, and its source code is available
+-- here: https://github.com/NotMyWing/GarrysModAmongUs
+-- The code you see here is the result of compiled code, and is probably not
+-- something you want to edit directly. Please consider editing the original
+-- gamemode source off GitHub instead.`;
+
+/**
+ * Discourage direct Lua file modification by notifying users where to find
+ * the uncompiled gamemode source code.
+ */
+class DiscourageLuaModificationTransform extends Transform {
+
+	constructor() {
+		super({ objectMode: true });
+	}
+
+	/**
+	 * Transforms a file.
+	 * @param {Object} file The file to process.
+	 * @param {string} encoding The encoding of the file.
+	 * @param {Function} next A callback function.
+	 */
+	_transform(file, encoding, next) {
+		if (file.isNull()) {
+			return next(null, file);
+		}
+
+		if (file.isStream()) {
+			streamToBuffer(file.contents, (err, contents) => {
+				if (err) this.emit('error', err);
+				else {
+					const code = contents.toString(encoding);
+					file.contents = Buffer.from(LUA_FILE_PREFIX + '\n\n' + code, encoding);
+					next(null, file);
+				}
+			});
+		}
+
+		if (file.isBuffer()) {
+			const code = file.contents.toString(encoding);
+			file.contents = Buffer.from(LUA_FILE_PREFIX + '\n\n' + code, encoding);
+			next(null, file);
+		}
+	}
+}
+
+module.exports = () => new DiscourageLuaModificationTransform();
+module.exports.DiscourageLuaModificationTransform = DiscourageLuaModificationTransform;


### PR DESCRIPTION
The Lua code Moonscript produces is not very pleasant to look at or edit, and edits made to it cannot be easily incorporated back into the gamemode. This PR adds a comment to the top of every transpiled file letting users know where to find the uncompiled gamemode source code, and encouraging them to make their edits to it rather than to the compiled addon.