### PR TITLE
Fix Lua/netmessage error when spectators chat

### DIFF
--- a/src/gamemodes/amongus/gamemode/sv_player.moon
+++ b/src/gamemodes/amongus/gamemode/sv_player.moon
@@ -479,8 +479,8 @@ hook.Add "PlayerSay", "NMW AU DeadChat", (ply) ->
 	if not GAMEMODE\IsMeetingInProgress!
 		playerTable = IsValid(ply) and ply\GetAUPlayerTable!
 
-		-- ...unless he's dead/a spectator.
-		if (playerTable and not ply\IsDead!) or not playerTable
+		-- ... but only if they're a living player
+		if (playerTable and not ply\IsDead!)
 			GAMEMODE\Net_SendGameChatError playerTable
 			return ""
 


### PR DESCRIPTION
Spectators should not be suppressed by the `NMW AU DeadChat` hook, only living players.

In response to the following screenshot from the Discord:

![Spectator throwing errors when chatting](https://cdn.discordapp.com/attachments/784594698278010881/792527443834961950/unknown.png)